### PR TITLE
fixing karma configuration

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,17 +36,7 @@ module.exports = function(config) {
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-      'test/**/*.js': ['babel'],
-      'src/**/*.js': ['babel']
-    },
-    '6to5Preprocessor': {
-      options: {
-        sourceMap: 'inline',
-        modules: 'system',
-        moduleIds: false
-      }
-    },
+    preprocessors: { },
 
 
     // test results reporter to use

--- a/mock/socket-io.js
+++ b/mock/socket-io.js
@@ -1,46 +1,46 @@
-export default {
-  connect: createMockSocketObject
+let io = {
+  connect: function() {
+    return {
+      on: function (ev, fn) {
+        (this._listeners[ev] = this._listeners[ev] || []).push(fn);
+      },
+      once: function (ev, fn) {
+        (this._listeners[ev] = this._listeners[ev] || []).push(fn);
+        fn._once = true;
+      },
+      emit: function (ev, data) {
+        if (this._listeners[ev]) {
+          var args = arguments;
+          this._listeners[ev].forEach(function (listener) {
+            if (listener._once) {
+              this.removeListener(ev, listener);
+            }
+            listener.apply(null, Array.prototype.slice.call(args, 1));
+          }.bind(this));
+        }
+      },
+      _listeners: {},
+      removeListener: function (ev, fn) {
+        if (fn) {
+          var index = this._listeners[ev].indexOf(fn);
+          if (index > -1) {
+            this._listeners[ev].splice(index, 1);
+          }
+        } else {
+          delete this._listeners[ev];
+        }
+      },
+      removeAllListeners: function (ev) {
+        if (ev) {
+          delete this._listeners[ev];
+        } else {
+          this._listeners = {};
+        }
+      },
+      disconnect: function () {},
+      connect: function () {}
+    };
+  }
 };
 
-var createMockSocketObject = function() {
-  return {
-    on: function (ev, fn) {
-      (this._listeners[ev] = this._listeners[ev] || []).push(fn);
-    },
-    once: function (ev, fn) {
-      (this._listeners[ev] = this._listeners[ev] || []).push(fn);
-      fn._once = true;
-    },
-    emit: function (ev, data) {
-      if (this._listeners[ev]) {
-        var args = arguments;
-        this._listeners[ev].forEach(function (listener) {
-          if (listener._once) {
-            this.removeListener(ev, listener);
-          }
-          listener.apply(null, Array.prototype.slice.call(args, 1));
-        }.bind(this));
-      }
-    },
-    _listeners: {},
-    removeListener: function (ev, fn) {
-      if (fn) {
-        var index = this._listeners[ev].indexOf(fn);
-        if (index > -1) {
-          this._listeners[ev].splice(index, 1);
-        }
-      } else {
-        delete this._listeners[ev];
-      }
-    },
-    removeAllListeners: function (ev) {
-      if (ev) {
-        delete this._listeners[ev];
-      } else {
-        this._listeners = {};
-      }
-    },
-    disconnect: function () {},
-    connect: function () {}
-  };
-}
+export default io;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "src/bindtable.js",
   "scripts": {
     "test": "./node_modules/.bin/karma start --browsers Chrome --single-run"
-  },  
+  },
   "jspm": {
     "main": "system/index",
     "format": "register",
@@ -53,7 +53,6 @@
     "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.28",
-    "karma-babel-preprocessor": "^4.0.0",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
     "karma-jspm": "^1.1.4",


### PR DESCRIPTION
karma-jspm is being used so karma-babel-preprocessor is not necessary
anymore as karma-jspm handles es6 transpilation and module loading.

The karma babel preprocessor was creating a conflict with karma-jspm,
so I removed babel configuration in karma and uninstalled the npm
package.

Also, for some reason the connect function of the exported object in
socket-io mock was undefined, so I created the object with the function
inside of the definition and export the instance of that object, now it
seems to be working.

The tests still are failing but for other issues outside of the scope of this pull request. I can address them in future a PR.
