### PR TITLE
clean up tests, bindtable and started cleaning record

### DIFF
--- a/spec/bindtable.spec.js
+++ b/spec/bindtable.spec.js
@@ -1,234 +1,189 @@
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1500;
 
-import {BindTable, createBindTable} from '../src/bindtable';
+import BindTable from '../src/bindtable';
 import io from '../mock/socket-io';
 
-console.log('IO', io);
-console.log('BindTable', BindTable);
-console.log('createBindTable', createBindTable);
-
-// // import 'co' from 'co-mocha';
-
-// TODO: Clean up!
-// Enable support for generators in Mocha tests
-// function*
-//   yield
-
-// Jasmine
-// http://jasmine.github.io/2.2/introduction.html
-// http://jasmine.github.io/2.2/introduction.html#section-Asynchronous_Support
-
-
-// http://www.html5rocks.com/en/tutorials/es6/promises/
-describe('Promise', function(){
-  it('resolve should resolve', function(done){
-    var promise = new Promise(function(resolve, reject) {
-      resolve('ok');
-    });
-    // return promise;
-    promise.then(function(res) {
-      expect(res).toEqual('ok')
-      done();
-    })
-  });
-
-  it('reject should reject', function(done){
-    var promise = new Promise(function(resolve, reject) {
-      reject('err');
-    });
-    // return promise;
-    promise.then(function(res) {
-      done();
-    }, function(err) {
-      expect(err).toEqual('err')
-      done();
-    })
-  });
-});
-
-describe('bindTable', function(){
+describe('BindTable', () => {
   var mockSocket;
   var bindTable;
 
-  beforeEach(function(done) {
-    console.log('io in before each', io);
-    console.log('BindTable in before each', BindTable);
-
+  beforeEach(() => {
     mockSocket = io.connect();
-    console.log('mockSocket', mockSocket);
-
-    bindTable = createBindTable({
-      socket: mockSocket
-    });
-
-    console.log('bindTable', bindTable);
-    done();
+    bindTable = BindTable.create({socket: mockSocket});
   });
 
-  it('should add a record that is returned in promise', function(done){
-    mockSocket.on('myTable:add', function(data, cb){
+  afterEach(() => {
+    mockSocket = null;
+    bindTable = null;
+  });
+
+  it('should add a record that is returned in promise', done => {
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 123;
       cb(null, data);
     });
-    var myTable = bindTable.table('myTable');
-    myTable.add({name: 'james'})
-      .then(function(record){
-        console.log('added', record);
-        expect(record.id).toEqual(123);
-        done();
-      });
+
+    let assert = record => {
+      expect(record.id).toEqual(123);
+      done();
+    };
+
+    bindTable.table('myTable')
+             .add({name: 'james'})
+             .then(assert);
   });
 
-
-
-  it('should add a record that is returned in promise', function(done){
-    mockSocket.on('myTable:add', function(data, cb){
+  it('should add a record that is returned in promise', (done) => {
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 123;
       cb(null, data);
     });
-    var myTable = bindTable.table('myTable');
-    myTable.add({name: 'james'})
-      .then(function(record){
-        console.log('added', record);
-        expect(record.id).toEqual(123);
-        done();
-      });
+
+    let assert = record => {
+      expect(record.id).toEqual(123);
+      done();
+    };
+
+    bindTable.table('myTable')
+             .add({name: 'james'})
+             .then(assert);
   });
 
-  it('should add a record that is in rows array', function (done){
-    mockSocket.on('myTable:add', function(data, cb){
+  it('should add a record that is in rows array', (done) => {
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 123;
       cb(null, data);
     });
+
+    let assert = record => {
+      expect(myTable.rows.length).toEqual(1);
+      done();
+    };
+
     var myTable = bindTable.table('myTable');
     myTable.add({name: 'james'})
-      .then(function(record){
-        expect(myTable.rows.length).toEqual(1);
-        done();
-      });
+           .then(assert);
   });
 
-  it('should update an existing record', function (done) {
-    mockSocket.on('myTable:add', function(data, cb){
+  it('should update an existing record', (done) => {
+    mockSocket.on('myTable:update', (data, cb) => cb(null, data));
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 123;
       cb(null, data);
     });
-    mockSocket.on('myTable:update', function(data, cb){
-      cb(null, data);
-    });
 
-    console.log('bindTable', bindTable);
+    let update = record => {
+      record.name = 'James Moore';
+      return myTable.update(record);
+    };
+
+    let assert = updatedRecord => {
+      expect(updatedRecord.name).toEqual('James Moore');
+      done();
+    };
+
     var myTable = bindTable.table('myTable');
     myTable.add({name: 'james'})
-      .then(function(record){
-        record.name = 'James Moore';
-        return myTable.update(record);
-      })
-      .then(function(updatedRecord){
-        expect(updatedRecord.name).toEqual('James Moore');
-        done();
-      });
+           .then(update)
+           .then(assert);
   });
 
-  it('should update an existing record in the rows array', function(done){
-    mockSocket.on('myTable:add', function(data, cb){
+  it('should update an existing record in the rows array', (done) => {
+    mockSocket.on('myTable:update', (data, cb) => cb(null, data));
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 123;
       cb(null, data);
     });
-    mockSocket.on('myTable:update', function(data, cb){
-      cb(null, data);
-    });
 
-    console.log('bindTable', bindTable);
+    let update = record => {
+      record.name = 'James Moore';
+      return myTable.update(record);
+    };
+
+    let assert = updatedRecord => {
+      expect(myTable.rows[0].name).toEqual('James Moore');
+      done();
+    };
+
     var myTable = bindTable.table('myTable');
     myTable.add({name: 'james'})
-      .then(function(record){
-        record.name = 'James Moore';
-        return myTable.update(record);
-      })
-      .then(function(updatedRecord){
-        expect(myTable.rows[0].name).toEqual('James Moore');
-        done();
-      });
+           .then(update)
+           .then(assert);
   });
 
-  it('should not update other records in rows array', function(done){
+  it('should not update other records in rows array', (done) => {
     var idCounter = 0;
-    mockSocket.on('myTable:add', function(data, cb){
+    mockSocket.on('myTable:update', (data, cb) => cb(null, data));
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = ++idCounter;
       cb(null, data);
     });
-    mockSocket.on('myTable:update', function(data, cb){
-      cb(null, data);
-    });
+
+    let addAnother = record => myTable.add({name: 'james'});
+
+    let update = record => {
+      record.name = 'James Moore';
+      return myTable.update(record);
+    };
+
+    let assert = updatedRecord => {
+      expect(myTable.rows[0].name).toEqual('Bob');
+      expect(myTable.rows[1].name).toEqual('James Moore')
+      done();
+    };
 
     var myTable = bindTable.table('myTable');
     myTable.add({name: 'Bob'})
-      .then(function(record){
-        return myTable.add({name: 'james'});
-      })
-      .then(function(record){
-        record.name = 'James Moore';
-        return myTable.update(record);
-      })
-      .then(function(updatedRecord){
-        expect(myTable.rows[0].name).toEqual('Bob');
-        done();
-      });
+           .then(addAnother)
+           .then(update)
+           .then(assert);
   });
 
-  it('should delete a record', function(done){
+  it('should delete a record', (done) => {
     var idCounter = 0;
-    mockSocket.on('myTable:add', function(data, cb){
+    mockSocket.on('myTable:delete', (data, cb) => cb(null, data));
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = ++idCounter;
       cb(null, data);
     });
-    mockSocket.on('myTable:delete', function(data, cb){
-      cb(null, data);
-    });
+
+    let addAnother = record => myTable.add({name: 'Bob'});
+
+    let deleteRecord = record => myTable.delete(record);
+
+    let assert = result => {
+      expect(myTable.rows.length).toEqual(1);
+      expect(myTable.rows[0].name).toEqual('James');
+      done();
+    };
+
     var myTable = bindTable.table('myTable');
     myTable.add({name: 'James'})
-      .then(function (record) {
-        console.log('adding', record);
-        return myTable.add({name: 'Bob'})
-      })
-      .then(function(record){
-        console.log('deleting', record);
-        return myTable.delete(record)
-      })
-      .then(function(result){
-        console.log('result', result);
-        expect(myTable.rows.length).toEqual(1);
-        done();
-      });
+           .then(addAnother)
+           .then(deleteRecord)
+           .then(assert);
   });
 
-  it('should update array automatically on outside update', function(done){
-    mockSocket.on('myTable:add', function(data, cb){
+  it('should update array automatically on outside update', (done) => {
+    var changes = {
+      new_val: { id: 100, name: 'James Moore' },
+      old_val: { id: 100, name: 'James'}
+    };
+    mockSocket.on('myTable:add', (data, cb) => {
       data.id = 100;
       cb(null, data);
     });
 
+    let updateAndAssert = record => mockSocket.emit('myTable:changes', changes, assert);
+
+    let assert = (err, response) => {
+      expect(myTable.rows[0].name).toEqual('James Moore');
+      done();
+    };
+
     var myTable = bindTable.table('myTable');
-    console.log('myTable', myTable);
-    console.log('table', myTable.table);
     myTable.bind({}, 10, 0);
     myTable.add({name: 'James'})
-      .then(function(record){
-        var changes = {
-          new_val: {
-            id: 100,
-            name: 'James Moore'
-          },
-          old_val: {
-            id: 100,
-            name: 'James'
-          }
-        };
-        mockSocket.emit('myTable:changes', changes, function(err, response){
-          expect(myTable.rows[0].name).toEqual('James Moore');
-          done();
-        })
-      });
+           .then(updateAndAssert);
   });
 });

--- a/src/bindable.js
+++ b/src/bindable.js
@@ -1,20 +1,20 @@
-import {BindTable, createBindTable} from './bindtable';
+import BindTable from './bindtable';
 
 export class Bindable {
   static inject() { return [BindTable]; }
 
-  constructor(bindTable, socket) {  
-    this.bindTable = createBindTable({socket:socket});
+  constructor(bindTable, socket) {
+    this.bindTable = BindTable.create({socket:socket});
     super();
   }
 
-  get tableName() {   
+  get tableName() {
     throw "tableName not defined";
   }
 
-  get rowLimit() {   
+  get rowLimit() {
     return 100;
-  }  
+  }
 
   filter() {
     // calling bind(filter, limit, offset) creates a rows
@@ -33,5 +33,5 @@ export class Bindable {
 
   deactivate() {
     this.table.unBind();
-  }    
+  }
 }

--- a/src/bindtable.js
+++ b/src/bindtable.js
@@ -4,25 +4,18 @@
  */
 
 import Record from './record';
-import Table  from './table'; 
+import Table  from './table';
 
-export function createBindTable(options) {
-  return new BindTable(options);
-}
-
-export class BindTable {
-  constructor(options) {
-    if(!options || !options.socket){
+export default class BindTable {
+  constructor(options = {}) {
+    if (!options.socket) {
       throw new Error('must supply a socket io connection');
     }
-    options.socket    = options.socket || BindTable.defaultSocket();
+    options.socket    = options.socket;
     this.options      = options;
     this.type         = 'BindTable';
-    BindTable.options = options;
-
-    BindTable.socket  = options.socket;
   }
-  
+
   table(tableName, options) {
     options = options || this.options;
     options.socket    = options.socket || BindTable.socket;
@@ -31,9 +24,5 @@ export class BindTable {
 
   static create(options) {
     return new BindTable(options);
-  }
-
-  static defaultSocket() {
-    throw "Please define a static Record defaultSocket function";
   }
 }

--- a/src/record.js
+++ b/src/record.js
@@ -10,68 +10,51 @@ export default class Record {
 
   update() {
     this.log('update');
-    let table = this.table;
-    let record = this.record;
-    let socket = this.socket;
-    let that   = this;
-    var promise = createPromise(function(resolve, reject) {      
-      socket.emit(table.updateEventName, record, function(err, result) {
-        if (err){
+    let emitUpdate = (resolve, reject) => {
+      this.socket.emit(this.table.updateEventName, this.record, (err, result) => {
+        if (err) {
           reject(err);
+          return;
         }
-        else {
-          that.upsertLocalRow();
-          resolve(result);
-        }
+        this.upsertLocalRow();
+        resolve(result);
       });
-    });
-    return promise;
+    };
+    return createPromise(emitUpdate);
   }
 
   add() {
     this.log('add');
-    let table = this.table;
-    let record = this.record;
-    let socket = this.socket;
-    let that   = this;
-    var promise = createPromise(function(resolve, reject) {
-      socket.emit( table.addEventName, record, function(err, record) {
+    let emitAdd = (resolve, reject) => {
+      this.socket.emit(this.table.addEventName, this.record, (err, result) => {
         if (err){
-          console.log('rejecting', record, err);
+          console.log('rejecting', this.record, err);
           reject(err);
+          return;
         }
-        else {
-          console.log('upsert row', record);
-          that.upsertLocalRow();
-          console.log('resolving', record);
-          resolve(record);
-        }
+        console.log('upsert row', this.record);
+        this.upsertLocalRow();
+        console.log('resolving', this.record);
+        resolve(result);
       });
-    });
-
-    console.log('returning promise', promise);
-    return promise;
+    };
+    return createPromise(emitAdd);
   }
 
   delete() {
     this.log('delete');
-    let table = this.table;
-    let record = this.record;
-    let socket = this.socket;
-    let that   = this;
-    var promise = createPromise(function(resolve, reject) {
-      socket.emit(table.deleteEventName, record.id, function(err, result){
-        if(err) {
+    let emitDelete = (resolve, reject) => {
+      this.socket.emit(this.table.deleteEventName, this.record.id, (err, result) => {
+        if (err) {
           this.error(err);
           reject(err);
+          return;
         }
-        else {
-          that.deleteLocalRow(record.id);
-          resolve(result);
-        }
+        this.deleteLocalRow(this.record.id);
+        resolve(result);
       });
-    });
-    return promise;
+    };
+    return createPromise(emitDelete);
   }
 
   deleteLocalRow(id){
@@ -118,7 +101,7 @@ export default class Record {
       if (row === undefined) {
         console.log('WARNING: row', i, 'is undefined for', rows);
         return -1;
-      }      
+      }
       console.log('find match', rows, row, i, pkName, record)
       if (row[pkName] === record[pkName]) {
         return i;

--- a/src/table.js
+++ b/src/table.js
@@ -1,11 +1,11 @@
 import createPromise from './util';
 import Record from './record';
 
-console.log('imported Record', Record);
+//console.log('imported Record', Record);
 
 export default class Table {
-  constructor(tableName, options) {
-    console.log('create table', tableName);
+  constructor(tableName, options = {}) {
+    //console.log('create table', tableName);
 
     this.socket = options.socket;
     let table = {};
@@ -14,19 +14,19 @@ export default class Table {
     this.type = 'Table';
     table.tableName = tableName;
 
-    table.addEventName = options.addEventName 
+    table.addEventName = options.addEventName
       || table.tableName + ':add';
 
-    table.findEventName = options.findEventName 
+    table.findEventName = options.findEventName
       || table.tableName + ':findById';
 
-    table.updateEventName = options.updateEventName 
+    table.updateEventName = options.updateEventName
       || table.tableName + ':update';
 
-    table.deleteEventName = options.deleteEventName 
+    table.deleteEventName = options.deleteEventName
       || table.tableName + ':delete';
 
-    table.startChangesEventName = options.startChangesEventName 
+    table.startChangesEventName = options.startChangesEventName
       || tableName + ':changes:start';
 
     table.endChangesEventName = options.endChangesEventName
@@ -47,11 +47,11 @@ export default class Table {
     table.add       = this.add;
     table.update    = this.update;
     table.findById  = this.findById;
-    table.log       = this.log; 
+    table.log       = this.log;
     table.table     = table;
 
     table.save = (record) => {
-      console.log('Save:', record);
+      //console.log('Save:', record);
       return record.id ? this.update(record) : this.add(record);
     }
 
@@ -62,14 +62,14 @@ export default class Table {
 
     this.table = table;
 
-    console.log('table created', this.table);
+    //console.log('table created', this.table);
 
     return table;
   }
 
   on(record) {
     this.log('on');
-    console.log('Record', record);
+    //console.log('Record', record);
     return new Record(this, record);
   }
 
@@ -97,14 +97,14 @@ export default class Table {
 
   findInsertIndex(record){
     this.log('findInsertIndex');
-    return this.on(record).findInsertIndex(); 
+    return this.on(record).findInsertIndex();
   }
 
   findById(id) {
     this.log('findById');
     let table = this.table;
     let socket = this.socket;
-    var promise = createPromise(function(reject, resolve) {      
+    var promise = createPromise(function(reject, resolve) {
       socket.emit(table.findEventName, id, function(err, result){
         if(err){
           reject(err);
@@ -128,13 +128,13 @@ export default class Table {
     rows = rows || [];
     for (var i = 0; i < rows.length; i++) {
       var row = rows[i];
-      console.log('find match', row, i, pkName, record)
+      //console.log('find match', row, i, pkName, record)
       if(row[pkName] === record[pkName]){
         return i;
       }
     };
     return -1;
-  } 
+  }
 
   remove(rows, id, pkName) {
     this.log('remove');
@@ -152,14 +152,14 @@ export default class Table {
   updateLocalRows(change){
     this.log('updateLocalRows');
     let table = this.table;
-    console.log('change', change);
+    //console.log('change', change);
 
     if(change.new_val === null){
-      console.log('deleting', change.old_val.id);
+      //console.log('deleting', change.old_val.id);
       this.deleteLocalRow(change.old_val.id);
     }
     else{
-      console.log('upserting', change.new_val);
+      //console.log('upserting', change.new_val);
       this.upsertLocalRow(change.new_val);
     }
   }
@@ -170,12 +170,12 @@ export default class Table {
     let table         = this.table;
     var changeOptions = {
       limit: limit || 10,
-      offset: offset || 0, 
+      offset: offset || 0,
       filter: filter || {}
     };
-    console.log('this', this);
-    console.log('table', table);
-    console.log('startWatchingChanges', this.startWatchingChanges);
+    //console.log('this', this);
+    //console.log('table', table);
+    //console.log('startWatchingChanges', this.startWatchingChanges);
 
     this.startWatchingChanges(changeOptions);
 
@@ -187,17 +187,17 @@ export default class Table {
   }
 
 
-  reconnect(options){    
+  reconnect(options){
     var that = this;
     let socket = this.socket;
     let table = this.table;
     return function() {
       that.log('reconnectHandler');
-      socket.emit(table.startChangesEventName, options);  
-    }    
+      socket.emit(table.startChangesEventName, options);
+    }
   }
 
-  startWatchingChanges(options) {    
+  startWatchingChanges(options) {
     let socket = this.socket;
     let table = this.table;
     this.log('startWatchingChanges');
@@ -211,13 +211,13 @@ export default class Table {
       that.updateLocalRows(change)
       if(cb){
         cb(null);
-      }      
+      }
     }
   }
 
   unBind() {
     this.log('unBind');
-    let socket = this.socket;    
+    let socket = this.socket;
     let table = this.table;
     socket.emit(table.endChangesEventName);
     socket.removeListener(table.listenEventName, table.changeHandler);


### PR DESCRIPTION
BindTable tests:
- Replace normal function declaration for arrow functions.
- Remove comments and console.log calls.
- Promise callbacks were extracted to named functions to improve code
  readability.

BindTable:
- Remove unnecessary code.
- Make BindTable class default export.
- Use static create function instead of createBindTable function.

Record:
- Promise callbacks were extracted to named functions to improve code
  readability in add, update and delete functions.
